### PR TITLE
correct import name

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 package main
 
-import _ "github.com/carolynvs/deptest-importer/subpkgB"
+import _ "github.com/carolynvs/deptest-importers/subpkgB"
 
 func main() {}


### PR DESCRIPTION
Importing this project was failing due to the typo:
```
failed to set up "https://github.com/carolynvs/deptest-importer", error remote repository at https://github.com/carolynvs/deptest-importer does not exist, or is inaccessible: command failed: [git ls-remote https://github.com/carolynvs/deptest-importer]: exit status 128
```